### PR TITLE
perf(blog): load post metadata only, lazy-load bodies per post

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,4 @@
-import type { Post } from "$lib/posts";
+import type { PostPreview } from "$lib/posts";
 
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
@@ -7,7 +7,7 @@ declare global {
     // interface Error {}
     // interface Locals {}
     interface PageData {
-      posts: Post[];
+      posts: PostPreview[];
     }
     // interface PageState {}
     // interface Platform {}

--- a/src/components/blog-post-card.svelte
+++ b/src/components/blog-post-card.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import type { Post } from "$lib/posts";
+  import type { PostPreview } from "$lib/posts";
   import { textToId } from "../routes/blog/[slug]/+page.svelte";
 
-  type Props = Post;
+  type Props = PostPreview;
 
   let { meta }: Props = $props();
 </script>

--- a/src/lib/posts/index.ts
+++ b/src/lib/posts/index.ts
@@ -3,29 +3,40 @@ import matter from "gray-matter";
 import * as v from "valibot";
 
 /**
- * Returns an array of posts, newest first
- *
- * @returns An array of posts
+ * Lazy per-file loaders for the raw markdown. Because the glob is *not* eager,
+ * a post's body is only imported when its loader is invoked, so an individual
+ * post page pulls in just its own markdown instead of every post's content.
  */
-export function listPosts() {
-  try {
-    const rawPosts = Object.entries(import.meta.glob("./*.md", { eager: true, query: "?raw" }));
+const postFiles = import.meta.glob("./*.md", { query: "?raw", import: "default" }) as Record<
+  string,
+  () => Promise<string>
+>;
 
-    const allPosts = rawPosts.map(([path, module]) => {
-      return parsePost(module.default, path);
-    });
+const stringSchema = v.pipe(v.string(), v.trim(), v.minLength(1));
 
-    const publishedPosts = dev
-      ? allPosts.map((p) => {
-          if (p.meta.publishedOn) return p;
-          return { ...p, meta: { ...p.meta, publishedOn: new Date() } };
-        })
-      : allPosts.filter((post) => !!post.meta.publishedOn);
+const metaSchema = v.object({
+  title: stringSchema,
+  publishedOn: v.optional(v.date()),
+  tagline: stringSchema,
+  slug: stringSchema,
+  tags: v.fallback(v.array(stringSchema), []),
+  thumbnailSrc: v.optional(stringSchema),
+  thumbnailAlt: v.optional(stringSchema),
+  readingTime: v.number(),
+});
 
-    return publishedPosts.sort((a, b) => b.meta.publishedOn.getTime() - a.meta.publishedOn.getTime());
-  } catch {
-    return [];
-  }
+const postSchema = v.object({
+  content: stringSchema,
+  meta: metaSchema,
+});
+
+export type PostMeta = v.InferOutput<typeof metaSchema>;
+/** A post without its (potentially large) markdown body. */
+export type PostPreview = { meta: PostMeta };
+export type Post = v.InferOutput<typeof postSchema>;
+
+function pathToSlug(path: string): string {
+  return path.slice(2, -3);
 }
 
 /**
@@ -42,42 +53,82 @@ function calculateReadingTime(content: string, wordsPerMinute = 100): number {
 }
 
 /**
- * Given a path to a post, will return the content of the file
+ * Parses a raw markdown file (frontmatter + body) into a fully typed post.
  *
- * @param content The path to the file
- * @returns A string containing the contents of the file
+ * @param raw The raw contents of the markdown file
+ * @param path The glob path of the file, used to derive the slug
+ * @returns The parsed post
  */
-function parsePost(content: string, path: string) {
-  const slug = path.slice(2, -3);
-  const raw = matter(content);
-  const readingTime = calculateReadingTime(raw.content);
+function parsePost(raw: string, path: string): Post {
+  const slug = pathToSlug(path);
+  const parsed = matter(raw);
+  const readingTime = calculateReadingTime(parsed.content);
 
-  const parsed = v.safeParse(postSchema, {
-    content: raw.content,
-    meta: { ...raw.data, slug, readingTime },
+  const result = v.safeParse(postSchema, {
+    content: parsed.content,
+    meta: { ...parsed.data, slug, readingTime },
   });
 
-  if (!parsed.success) {
-    throw new Error(`Cannot parse file '${content}'`);
+  if (!result.success) {
+    throw new Error(`Cannot parse post '${slug}'`);
   }
 
-  return parsed.output;
+  return result.output;
 }
 
-const stringSchema = v.pipe(v.string(), v.trim(), v.minLength(1));
+/** In dev, posts without a publish date are treated as published "now". */
+function withDevDate<T extends PostPreview>(post: T): T {
+  if (!dev || post.meta.publishedOn) return post;
+  return { ...post, meta: { ...post.meta, publishedOn: new Date() } };
+}
 
-const postSchema = v.object({
-  content: stringSchema,
-  meta: v.object({
-    title: stringSchema,
-    publishedOn: v.optional(v.date()),
-    tagline: stringSchema,
-    slug: stringSchema,
-    tags: v.fallback(v.array(stringSchema), []),
-    thumbnailSrc: v.optional(stringSchema),
-    thumbnailAlt: v.optional(stringSchema),
-    readingTime: v.number(),
-  }),
-});
+function isPublished(post: PostPreview): boolean {
+  return dev || !!post.meta.publishedOn;
+}
 
-export type Post = v.InferOutput<typeof postSchema>;
+function byNewest(a: PostPreview, b: PostPreview): number {
+  return (b.meta.publishedOn?.getTime() ?? 0) - (a.meta.publishedOn?.getTime() ?? 0);
+}
+
+/**
+ * Returns lightweight metadata for every published post, newest first.
+ *
+ * The markdown body is intentionally omitted so it is never serialized to
+ * pages that only need to list or link posts.
+ *
+ * @returns An array of post metadata
+ */
+export async function listPostsMeta(): Promise<PostPreview[]> {
+  try {
+    const posts = await Promise.all(
+      Object.entries(postFiles).map(async ([path, load]) => parsePost(await load(), path)),
+    );
+
+    return posts
+      .map(withDevDate)
+      .filter(isPublished)
+      .sort(byNewest)
+      .map(({ meta }) => ({ meta }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Loads a single post including its markdown body, lazily importing only that
+ * post's file.
+ *
+ * @param slug The slug of the post to load
+ * @returns The post, or null if it does not exist or is not published
+ */
+export async function getPost(slug: string): Promise<Post | null> {
+  const entry = Object.entries(postFiles).find(([path]) => pathToSlug(path) === slug);
+  if (!entry) return null;
+
+  const [path, load] = entry;
+  const post = withDevDate(parsePost(await load(), path));
+
+  if (!isPublished(post)) return null;
+
+  return post;
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,5 +1,5 @@
-import { listPosts } from "$lib/posts";
+import { listPostsMeta } from "$lib/posts";
 
 export const prerender = true;
 
-export const load = () => ({ posts: listPosts() });
+export const load = async () => ({ posts: await listPostsMeta() });

--- a/src/routes/blog/[slug]/+page.server.ts
+++ b/src/routes/blog/[slug]/+page.server.ts
@@ -1,6 +1,6 @@
 import { error } from "@sveltejs/kit";
 import type { EntryGenerator, PageServerLoad } from "./$types";
-import { listPosts } from "$lib/posts";
+import { getPost, listPostsMeta } from "$lib/posts";
 
 export const load: PageServerLoad = async ({ params, parent }) => {
   const { posts } = await parent();
@@ -8,10 +8,12 @@ export const load: PageServerLoad = async ({ params, parent }) => {
   const postIdx = posts.findIndex((p) => p.meta.slug === params.slug);
   if (postIdx < 0) error(404, "Sorry, we couldn't find that post");
 
-  const prevPost = posts[postIdx + 1];
-  const nextPost = posts[postIdx - 1];
+  const post = await getPost(params.slug);
+  if (!post) error(404, "Sorry, we couldn't find that post");
 
-  const post = posts[postIdx];
+  const prevPost = posts[postIdx + 1] ?? null;
+  const nextPost = posts[postIdx - 1] ?? null;
+
   const relatedPosts = posts
     .filter((p, i) => i !== postIdx && p.meta.tags.some((t) => post.meta.tags.includes(t)))
     .slice(0, 2);
@@ -19,6 +21,6 @@ export const load: PageServerLoad = async ({ params, parent }) => {
   return { post, prevPost, nextPost, relatedPosts };
 };
 
-export const entries: EntryGenerator = () => {
-  return listPosts().map((p) => ({ slug: p.meta.slug }));
+export const entries: EntryGenerator = async () => {
+  return (await listPostsMeta()).map((p) => ({ slug: p.meta.slug }));
 };

--- a/src/routes/blog/[slug]/og/+server.ts
+++ b/src/routes/blog/[slug]/og/+server.ts
@@ -1,4 +1,4 @@
-import { listPosts } from "$lib/posts";
+import { getPost } from "$lib/posts";
 import { nodeToJpeg } from "./component-to-jpeg";
 import { error } from "@sveltejs/kit";
 
@@ -6,7 +6,7 @@ const width = 738;
 const height = 360;
 
 export const GET = async ({ params, url }) => {
-  const post = listPosts().find((post) => post.meta.slug == params.slug);
+  const post = await getPost(params.slug);
   if (!post) error(404, { message: "No post with that slug found" });
 
   const dark = url.searchParams.has("dark");

--- a/src/routes/blog/tags/[tag]/+page.server.ts
+++ b/src/routes/blog/tags/[tag]/+page.server.ts
@@ -1,4 +1,4 @@
-import { listPosts } from "$lib/posts/index.js";
+import { listPostsMeta } from "$lib/posts/index.js";
 import { error } from "@sveltejs/kit";
 
 export const load = async ({ parent, params }) => {
@@ -11,8 +11,8 @@ export const load = async ({ parent, params }) => {
   return { posts: filtered, tag };
 };
 
-export const entries = () => {
-  const posts = listPosts();
+export const entries = async () => {
+  const posts = await listPostsMeta();
   const tags = [...new Set(posts.map((p) => p.meta.tags).flat())];
 
   return tags.map((tag) => ({ tag: tag.replace(/\//g, "-") }));

--- a/src/routes/rss.xml/+server.ts
+++ b/src/routes/rss.xml/+server.ts
@@ -1,6 +1,8 @@
 import { PUBLIC_EMAIL, PUBLIC_URL } from "$env/static/public";
-import { listPosts } from "$lib/posts";
-import type { Post } from "$lib/posts";
+import { listPostsMeta } from "$lib/posts";
+import type { PostPreview } from "$lib/posts";
+
+export const prerender = true;
 
 const title = escapeXml("Bobby Mannino's Blog");
 const description = escapeXml("Some things I have learnt and would like to remember");
@@ -28,8 +30,9 @@ function escapeXml(raw: string) {
     .replace(/'/g, "&apos;");
 }
 
-function postToXml(post: Post) {
-  const { title, tagline, publishedOn, slug } = post.meta;
+function postToXml(post: PostPreview) {
+  const { title, tagline, slug } = post.meta;
+  const publishedOn = post.meta.publishedOn ?? new Date();
   const url = `${PUBLIC_URL}/blog/${slug}`;
 
   return `
@@ -46,8 +49,10 @@ function postToXml(post: Post) {
       `;
 }
 
-export const GET = () => {
-  return new Response(insertXml(listPosts().map(postToXml).join("")), {
+export const GET = async () => {
+  const posts = await listPostsMeta();
+
+  return new Response(insertXml(posts.map(postToXml).join("")), {
     headers: { "Content-Type": "application/rss+xml" },
   });
 };

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,8 +1,10 @@
 import { PUBLIC_URL } from "$env/static/public";
-import { listPosts } from "$lib/posts";
+import { listPostsMeta } from "$lib/posts";
 
-export const GET = () => {
-  const posts = listPosts();
+export const prerender = true;
+
+export const GET = async () => {
+  const posts = await listPostsMeta();
 
   return new Response(
     `<?xml version="1.0" encoding="UTF-8" ?>


### PR DESCRIPTION
## Summary

The root `+layout.server.ts` runs on **every** route and returned the full parsed content of every markdown post via `listPosts()`. Since the layout is prerendered, each page's data payload embedded the entire blog corpus — so the homepage, blog list, every tag page, etc. all shipped the full text of ~45 posts even though they only render titles/taglines.

This PR makes the layout ship **metadata only**, and lazily loads a post's body **only when you're on that actual post**.

## Changes

- **Split `src/lib/posts/index.ts`** into two APIs:
  - `listPostsMeta()` — returns lightweight metadata (no markdown body). Used by the layout, blog list, tag pages, search, RSS and sitemap.
  - `getPost(slug)` — lazily imports a single post's markdown via a **non-eager** `import.meta.glob`, so a post page pulls in only its own body. Each post now compiles to its own chunk.
- **`blog/[slug]/+page.server.ts`** loads the body through `getPost`; prev/next/related posts come from the metadata list.
- Updated all consumers (`og`, `rss.xml`, `sitemap.xml`, tag routes, `blog-post-card`) and the `App.PageData` / `PostPreview` types.
- **Bonus:** `rss.xml` and `sitemap.xml` are now prerendered (they were rendered on every request, but their output is fully static).

## Impact

| Page data payload (`__data.json`) | Before | After |
|---|---|---|
| Homepage | ~150 KB | ~11 KB |
| Blog list | ~150 KB | ~11 KB |

A **~93% reduction**, repeated across every prerendered page. Less data to download, parse, and hydrate on the entire site; individual post pages are unaffected (they still load their one body).

## Verification

- `bun run build` succeeds; confirmed each post emits its own server chunk and the homepage payload no longer contains post bodies.
- `bun run check`: no new type errors introduced (error count went **down** 54 → 50; the remainder are pre-existing, e.g. missing `PUBLIC_URL` env during check).

https://claude.ai/code/session_01He9XTe7KhtTsfPE4LGa5KW

---
_Generated by [Claude Code](https://claude.ai/code/session_01He9XTe7KhtTsfPE4LGa5KW)_