### PR TITLE
feat: add blog series support

### DIFF
--- a/src/lib/posts/index.ts
+++ b/src/lib/posts/index.ts
@@ -74,6 +74,7 @@ const postSchema = v.object({
     tagline: stringSchema,
     slug: stringSchema,
     tags: v.fallback(v.array(stringSchema), []),
+    series: v.optional(stringSchema),
     thumbnailSrc: v.optional(stringSchema),
     thumbnailAlt: v.optional(stringSchema),
     readingTime: v.number(),

--- a/src/lib/posts/which-editor-2024.md
+++ b/src/lib/posts/which-editor-2024.md
@@ -3,6 +3,7 @@ title: "Which Editor (2024)"
 publishedOn: 2024-12-27
 tagline: "Which editor should you use?"
 tags: ["zed", "vscode", "vim", "editor"]
+series: "which-editor"
 ---
 
 # Which Editor (2024)

--- a/src/lib/posts/which-editor-2026.md
+++ b/src/lib/posts/which-editor-2026.md
@@ -3,6 +3,7 @@ title: "Which Editor (2026)"
 publishedOn: 2026-05-28
 tagline: "Which editor should you use?"
 tags: ["zed", "vscode", "vim", "athas", "cursor", "editor"]
+series: "which-editor"
 ---
 
 # Which Editor (2026)

--- a/src/routes/blog/[slug]/info.svelte
+++ b/src/routes/blog/[slug]/info.svelte
@@ -62,6 +62,15 @@
       </li>
     {/each}
   </ul>
+  {#if post.meta.series}
+    <p class="text-zinc-500">
+      Part of the
+      <a href="/series/{post.meta.series}" class="text-accent-600 ring-on-focus-visible hover:underline">
+        {post.meta.series}
+      </a>
+      series
+    </p>
+  {/if}
   <div class="flex items-center gap-2 text-zinc-500">
     <span style:--vtn="post-{post.meta.slug}-meta">
       <time

--- a/src/routes/header.svelte
+++ b/src/routes/header.svelte
@@ -11,6 +11,7 @@
   const links = [
     { href: "/#about", text: "about" },
     { href: "/blog", text: "blog" },
+    { href: "/series", text: "series" },
     { href: "/#technologies", text: "technologies" },
     { href: "/#projects", text: "projects" },
     { href: "/#contact", text: "contact" },

--- a/src/routes/series/+page.svelte
+++ b/src/routes/series/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import type { PageProps } from "./$types";
+
+	let { data }: PageProps = $props();
+
+	const { series } = data;
+</script>
+
+<svelte:head>
+	<title>Blog Series</title>
+	<meta name="description" content="All blog post series" />
+</svelte:head>
+
+<main class="wrapper">
+	<h1>Blog Series</h1>
+
+	{#if series.length > 0}
+		<ul>
+			{#each series as s (s.slug)}
+				<li>
+					<a href="/series/{s.slug}">
+						<span class="title">{s.slug}</span>
+						<span class="count">
+							{s.count} post{s.count === 1 ? "" : "s"}
+						</span>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{:else}
+		<p>No series yet.</p>
+	{/if}
+</main>
+
+<style>
+	main {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	li a {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 1rem;
+		border: 1px solid var(--border);
+		border-radius: 0.5rem;
+	}
+
+	.count {
+		color: var(--text-muted);
+		font-size: 0.875rem;
+	}
+</style>

--- a/src/routes/series/+page.ts
+++ b/src/routes/series/+page.ts
@@ -1,16 +1,16 @@
 export const prerender = true;
 
 import type { PageLoad } from "./$types";
-import { getPosts } from "$lib/posts";
+import { listPosts } from "$lib/posts";
 
-export const load: PageLoad = async () => {
-	const posts = await getPosts();
+export const load: PageLoad = () => {
+	const posts = listPosts();
 
 	const counts = new Map<string, number>();
 
 	for (const post of posts) {
-		if (!post.series) continue;
-		counts.set(post.series, (counts.get(post.series) ?? 0) + 1);
+		if (!post.meta.series) continue;
+		counts.set(post.meta.series, (counts.get(post.meta.series) ?? 0) + 1);
 	}
 
 	const series = Array.from(counts.entries())

--- a/src/routes/series/+page.ts
+++ b/src/routes/series/+page.ts
@@ -1,0 +1,21 @@
+export const prerender = true;
+
+import type { PageLoad } from "./$types";
+import { getPosts } from "$lib/posts";
+
+export const load: PageLoad = async () => {
+	const posts = await getPosts();
+
+	const counts = new Map<string, number>();
+
+	for (const post of posts) {
+		if (!post.series) continue;
+		counts.set(post.series, (counts.get(post.series) ?? 0) + 1);
+	}
+
+	const series = Array.from(counts.entries())
+		.map(([slug, count]) => ({ slug, count }))
+		.sort((a, b) => a.slug.localeCompare(b.slug));
+
+	return { series };
+};

--- a/src/routes/series/[series]/+page.server.ts
+++ b/src/routes/series/[series]/+page.server.ts
@@ -1,13 +1,13 @@
 import type { EntryGenerator } from "./$types";
-import { getPosts } from "$lib/posts";
+import { listPosts } from "$lib/posts";
 
-export const entries: EntryGenerator = async () => {
-	const posts = await getPosts();
+export const entries: EntryGenerator = () => {
+	const posts = listPosts();
 
 	const series = new Set<string>();
 
 	for (const post of posts) {
-		if (post.series) series.add(post.series);
+		if (post.meta.series) series.add(post.meta.series);
 	}
 
 	return Array.from(series).map((series) => ({ series }));

--- a/src/routes/series/[series]/+page.server.ts
+++ b/src/routes/series/[series]/+page.server.ts
@@ -1,0 +1,14 @@
+import type { EntryGenerator } from "./$types";
+import { getPosts } from "$lib/posts";
+
+export const entries: EntryGenerator = async () => {
+	const posts = await getPosts();
+
+	const series = new Set<string>();
+
+	for (const post of posts) {
+		if (post.series) series.add(post.series);
+	}
+
+	return Array.from(series).map((series) => ({ series }));
+};

--- a/src/routes/series/[series]/+page.svelte
+++ b/src/routes/series/[series]/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import BlogPostCard from "$components/blog-post-card.svelte";
+	import type { PageProps } from "./$types";
+
+	let { data }: PageProps = $props();
+
+	const { series, posts } = data;
+</script>
+
+<svelte:head>
+	<title>Series: {series}</title>
+	<meta name="description" content="All blog posts in the {series} series" />
+</svelte:head>
+
+<main class="wrapper">
+	<h1>Series: {series}</h1>
+
+	<div class="posts">
+		{#each posts as post (post.slug)}
+			<BlogPostCard {post} />
+		{/each}
+	</div>
+</main>
+
+<style>
+	main {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.posts {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+</style>

--- a/src/routes/series/[series]/+page.svelte
+++ b/src/routes/series/[series]/+page.svelte
@@ -16,8 +16,8 @@
 	<h1>Series: {series}</h1>
 
 	<div class="posts">
-		{#each posts as post (post.slug)}
-			<BlogPostCard {post} />
+		{#each posts as post (post.meta.slug)}
+			<BlogPostCard {...post} />
 		{/each}
 	</div>
 </main>

--- a/src/routes/series/[series]/+page.ts
+++ b/src/routes/series/[series]/+page.ts
@@ -1,0 +1,22 @@
+export const prerender = true;
+
+import type { PageLoad } from "./$types";
+import { getPosts } from "$lib/posts";
+import { error } from "@sveltejs/kit";
+
+export const load: PageLoad = async ({ params }) => {
+	const { series } = params;
+
+	const posts = await getPosts();
+
+	// Oldest first so a series reads in order (part 1, part 2, ...)
+	const seriesPosts = posts
+		.filter((post) => post.series === series)
+		.sort((a, b) => a.publishedOn.getTime() - b.publishedOn.getTime());
+
+	if (seriesPosts.length === 0) {
+		error(404, `No posts found for series: ${series}`);
+	}
+
+	return { series, posts: seriesPosts };
+};

--- a/src/routes/series/[series]/+page.ts
+++ b/src/routes/series/[series]/+page.ts
@@ -1,18 +1,18 @@
 export const prerender = true;
 
 import type { PageLoad } from "./$types";
-import { getPosts } from "$lib/posts";
+import { listPosts } from "$lib/posts";
 import { error } from "@sveltejs/kit";
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = ({ params }) => {
 	const { series } = params;
 
-	const posts = await getPosts();
+	const posts = listPosts();
 
 	// Oldest first so a series reads in order (part 1, part 2, ...)
 	const seriesPosts = posts
-		.filter((post) => post.series === series)
-		.sort((a, b) => a.publishedOn.getTime() - b.publishedOn.getTime());
+		.filter((post) => post.meta.series === series)
+		.sort((a, b) => a.meta.publishedOn.getTime() - b.meta.publishedOn.getTime());
 
 	if (seriesPosts.length === 0) {
 		error(404, `No posts found for series: ${series}`);


### PR DESCRIPTION
Closes #50

## Summary

- Add optional `series` frontmatter field to post schema (`src/lib/posts/index.ts`) — each post can belong to 0 or 1 series
- Add `/series` index page listing all series with post counts
- Add `/series/[series]` detail page (oldest-first ordering, 404 on empty/invalid slug) with prerender entries
- Show series badge with link in blog post header (`info.svelte`) when a post belongs to a series
- Add "series" link to header nav
- Seed the first series (`which-editor`) with `which-editor-2024.md` and `which-editor-2026.md`

## Test plan

- [ ] `/series` lists the `which-editor` series with a post count of 2
- [ ] `/series/which-editor` shows both which-editor posts in chronological order
- [ ] `/series/does-not-exist` returns a 404
- [ ] Visiting either which-editor post shows a "Part of the which-editor series" badge linking to `/series/which-editor`
- [ ] Header nav includes a "series" link

https://claude.ai/code/session_01SQqMpAS89d88fHbyqDL7CC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQqMpAS89d88fHbyqDL7CC)_